### PR TITLE
Create license.txt

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -174,3 +174,15 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+Other dependencies and licenses:
+
+This product bundles RapidJSON, which is available under the "MIT" license. For
+details see one/arcus/internal/rapidjson.
+
+This product bundles, via RapidJSON, The msinttypes r29, which is available
+under the "BSD" license. For details see one/arcus/internal/rapidjson and
+one/arcus/internal/msinttypes.
+
+This product bundles Catch2, which is available under the "Boost Software
+License - Version 1.0" license. For details see tests/catch2.


### PR DESCRIPTION
apache 2.0 license

This change follows the particular instruction from apache for adding licenses to the main license:

> BUNDLING PERMISSIVELY-LICENSED DEPENDENCIES
>Bundling a dependency which is issued under one of the following licenses is straightforward, assuming that license applies uniformly to all files within the dependency:
>
>BSD (without advertising clause)
>MIT/X11
>In LICENSE, add a pointer to the dependency's license within the distribution and a short note summarizing its licensing:
>
>This product bundles SuperWidget 1.2.3, which is available under a "3-clause BSD" license. For details, see deps/superwidget/.
>
>Under normal circumstances, there is no need to modify NOTICE.
>
>NOTE: It's also possible to include the text of the 3rd party license within the LICENSE file. This is best reserved for short licenses. It's important to specify the version of the dependency as licenses are sometimes changed.
>
>There are a number of other "permissive" licenses which the ASF Legal Affairs Committee has approved for use. Some of these may require additions to NOTICE -- if in doubt, ask for assistance.

From this page:
https://www.apache.org/dev/licensing-howto.html

And it appears the added licenses are on the list of approved apache licenses for appending:
https://www.apache.org/legal/resolved.html#category-a

