### PR TITLE
Fix for compiling the OneClientPlugin for UnrealEngine5.4

### DIFF
--- a/one/ping/internal/udp_socket.cpp
+++ b/one/ping/internal/udp_socket.cpp
@@ -142,7 +142,6 @@ I3dPingError UdpSocket::reset() {
         default:
             return I3D_PING_ERROR_SOCKET_CANNOT_BE_RESET;
     }
-    return I3D_PING_ERROR_NONE;
 }
 
 I3dPingError UdpSocket::send_ping() {


### PR DESCRIPTION
## Summary
Received the following error when compiling the OneClientPlugin for UnrealEngine5.4:

[22/24] Compile [x64] udp_socket.cpp
C:\work\test\ArcusExample\Plugins\ONEGameClientPlugin\Source\ONEGameClientPlugin\Private\one\ping\internal\udp_socket.cpp(146) : error C4702: unreachable code while compiling i3d::ping::UdpSocket::reset

## Details
The reset function contained an unreachable return statement. 
Removing this return statement resolved the issue

## Type of change
- [X] Bug fix
- [  ] New feature
- [  ] Code style update (formatting, renaming)
- [  ] Refactoring (no functional changes, no API changes)
- [  ] Build related changes
- [  ] Documentation content changes
- [  ] Other

## Testing
Compiling now completes without errors. Further testing will continue once this merged change to the SDK is included in a new version of the plugin