### PR TITLE
Fixes for warnings when compiling for unreal editor 5.4

### DIFF
--- a/one/arcus/internal/accumulator.cpp
+++ b/one/arcus/internal/accumulator.cpp
@@ -39,6 +39,8 @@ void Accumulator::peek(size_t length, void **data) {
     }
     assert(data);
     assert(length <= _size);
+    // 'length' is only used for assertion, a void cast prevents unreferenced formal parameter warning.
+    (void)length;   
     *data = _buffer;
 }
 

--- a/one/arcus/internal/codec.cpp
+++ b/one/arcus/internal/codec.cpp
@@ -89,7 +89,8 @@ OneError message_to_data(const uint32_t packet_id, const Message &message,
     Header header{};
     header.opcode = static_cast<char>(message.code());
     header.packet_id = packet_id;
-    header.length = payload_length;
+    assert(payload_length <= UINT32_MAX);
+    header.length = (uint32_t) payload_length;
 
     std::array<char, header_size()> header_data;
     err = header_to_data(header, header_data);


### PR DESCRIPTION
## Summary
Compiling the SDK as part of the unreal 5.4 editor plugin gives 2 warnings. To guarantee submission of the plugin into the unreal marketplace these warnings are addressed in the SDK

## Details
1)
`codec.cpp(93): warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data`
fix: assert and cast to uint32

```
assert(payload_length <= UINT32_MAX);
header.length = (uint32_t) payload_length;
```

2)
`accumulator.cpp(37): warning C4100: 'length': unreferenced formal parameter`
fix: the 'length' parameter is used for assertion, and is marked unused by the compiler, added a void cast to have the 'length' variable be in use.

`(void)length; `

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build related changes
