### PR TITLE
Fixes for loss of data warnings when compiling for unreal editor 5.4

### DIFF
--- a/one/arcus/internal/codec.cpp
+++ b/one/arcus/internal/codec.cpp
@@ -90,7 +90,7 @@ OneError message_to_data(const uint32_t packet_id, const Message &message,
     header.opcode = static_cast<char>(message.code());
     header.packet_id = packet_id;
     assert(payload_length <= UINT32_MAX);
-    header.length = (uint32_t) payload_length;
+    header.length = static_cast<uint32_t>(payload_length);
 
     std::array<char, header_size()> header_data;
     err = header_to_data(header, header_data);

--- a/one/ping/sites_getter.cpp
+++ b/one/ping/sites_getter.cpp
@@ -239,7 +239,8 @@ I3dPingError SitesGetter::ipv4_list(IpList &ip_list) const {
 
     // Only take the first ip of the site.
     for (size_t i = 0; i < _sites.size(); ++i) {
-        err = ipv4(i, 0, ip);
+        assert(i <= UINT_MAX);
+        err = ipv4((unsigned int)i, 0, ip);
         if (i3d_ping_is_error(err)) {
             ip_list.clear();
             return err;
@@ -261,7 +262,8 @@ I3dPingError SitesGetter::ipv6_list(IpList &ip_list) const {
 
     // Only take the first ip of the site.
     for (size_t i = 0; i < _sites.size(); ++i) {
-        err = ipv6(i, 0, ip);
+        assert(i <= UINT_MAX);        
+        err = ipv6((unsigned int)i, 0, ip);
         if (i3d_ping_is_error(err)) {
             ip_list.clear();
             return err;

--- a/one/ping/sites_getter.cpp
+++ b/one/ping/sites_getter.cpp
@@ -240,7 +240,7 @@ I3dPingError SitesGetter::ipv4_list(IpList &ip_list) const {
     // Only take the first ip of the site.
     for (size_t i = 0; i < _sites.size(); ++i) {
         assert(i <= UINT_MAX);
-        err = ipv4((unsigned int)i, 0, ip);
+        err = ipv4(static_cast<unsigned int>(i), 0, ip);
         if (i3d_ping_is_error(err)) {
             ip_list.clear();
             return err;
@@ -263,7 +263,7 @@ I3dPingError SitesGetter::ipv6_list(IpList &ip_list) const {
     // Only take the first ip of the site.
     for (size_t i = 0; i < _sites.size(); ++i) {
         assert(i <= UINT_MAX);        
-        err = ipv6((unsigned int)i, 0, ip);
+        err = ipv6(static_cast<unsigned int>(i), 0, ip);
         if (i3d_ping_is_error(err)) {
             ip_list.clear();
             return err;


### PR DESCRIPTION
## Summary
Compiling the SDK as part of the unreal 5.4 editor plugin gives 2 additional loss of data warnings for one ping. To guarantee submission of the plugin into the unreal marketplace these warnings are addressed in the SDK

## Details

The 2 warnings are for an identical case:

`ONEGameClientPlugin\Private\one\ping\sites_getter.cpp(243): warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data`

`ONEGameClientPlugin\Private\one\ping\sites_getter.cpp(265): warning C4267: 'argument': conversion from 'size_t' to 'unsigned int', possible loss of data`

For both occurences an assert was used to verify a save converstion and a cast was added.

```
assert(i <= UINT_MAX);        
err = ipv6((unsigned int)i, 0, ip);

```
## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X ] Build related changes
- [ ] Documentation content changes
- [ ] Other