### PR TITLE
Default copy/assignment operator conflicts with const properties. 

### DIFF
--- a/one/ping/internal/pinger.h
+++ b/one/ping/internal/pinger.h
@@ -11,7 +11,7 @@ class Pinger final {
 public:
     Pinger();
     Pinger(const Pinger &) = default;
-    Pinger &operator=(const Pinger &) = default;
+    Pinger &operator=(const Pinger &) = delete;
     ~Pinger() = default;
 
     I3dPingError update();

--- a/one/ping/internal/udp_socket.h
+++ b/one/ping/internal/udp_socket.h
@@ -49,7 +49,7 @@ class UdpSocket final {
 public:
     UdpSocket();
     UdpSocket(const UdpSocket &) = default;
-    UdpSocket &operator=(const UdpSocket &) = default;
+    UdpSocket &operator=(const UdpSocket &) = delete;
     ~UdpSocket() = default;
 
     const String &ipv4() const {


### PR DESCRIPTION
## Summary
The default copy/assignment operators specified for the UdpSocket and Pinger class conflicts with the const private class member: UdpSocket._base_data  

## Details
The operator is removed from the UdpSocket and Pinger class by specifying it as = delete

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other
