### PR TITLE
changed submodule adress to https in stead of using ssh, so user can …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/curl"]
 	path = tests/curl
-	url = git@github.com:curl/curl.git
+	url = https://github.com/curl/curl.git


### PR DESCRIPTION
## Summary
Changed the address of the curl submodule to https

## Details
In case a user does not have github account set up with ssh keys they will clone the main SDK repo using https and then cannot clone the submodule using ssh (git@). Even with ssh keys properly added to github, using the ssh address of the submodule can have permission problems from the command prompt or powershell in stead of git bash even if the repository can be cloned successfully by itself.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other
